### PR TITLE
feat: add initial support for vapor components

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -175,7 +175,8 @@ export default function loader(
   const propsToAttach: [string, string][] = []
 
   // script
-  let scriptImport = `const script = {}`
+  const vaporFlag = descriptor.vapor ? '__vapor: true' : ''
+  let scriptImport = `const script = { ${vaporFlag} }`
   let isTS = false
   const { script, scriptSetup } = descriptor
   if (script || scriptSetup) {

--- a/src/resolveScript.ts
+++ b/src/resolveScript.ts
@@ -75,6 +75,7 @@ export function resolveScript(
         },
         transformAssetUrls: options.transformAssetUrls || true,
       },
+      vapor: descriptor.vapor,
     })
   } catch (e) {
     loaderContext.emitError(e)

--- a/src/templateLoader.ts
+++ b/src/templateLoader.ts
@@ -67,6 +67,7 @@ const TemplateLoader: LoaderDefinitionFunction = function (source, inMap: any) {
       ...resolveTemplateTSOptions(descriptor, options),
     },
     transformAssetUrls: options.transformAssetUrls || true,
+    vapor: descriptor.vapor,
   })
 
   // tips


### PR DESCRIPTION
I tried to test Vue Vapor with Rsbuild but couldn't make it work. I realized the loader was missing support for it, and since the original webpack loader seems to be abandoned, I created the PR here.

I've mostly copied the changes from @vite/plugin-vue, but it's just basically passing the new vapor property to be SFC compiler. While the flag is already available in the beta builds, I didn't bump the version of the devDependency. I don't really see any reason not to, as the vapor property seems to be stable by now.