### PR TITLE
chore: add Rslint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install Dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,34 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Pnpm
+        run: npm i -g corepack@latest --force && corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Run Lint
+        run: pnpm run lint

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ link.sh
 .cache
 TODOs.md
 coverage
-.vscode
+.vscode/*
+!.vscode/extensions.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "rstack.rslint",
+    "esbenp.prettier-vscode"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
     "dev-example": "node example/devServer.js --config example/webpack.config.js --inline --hot",
     "build-example": "rm -rf example/dist && webpack --config example/webpack.config.js --env.prod",
     "build-example-ssr": "rm -rf example/dist-ssr && webpack --config example/webpack.config.js --env.prod --env.ssr && node example/ssr.js",
-    "lint": "prettier --write --parser typescript \"{src,test}/**/*.{j,t}s\"",
-    "prepublishOnly": "tsc && conventional-changelog -p angular -i CHANGELOG.md -s -r 2"
+    "lint": "rslint",
+    "prepublishOnly": "tsc && conventional-changelog -p angular -i CHANGELOG.md -s -r 2",
+    "lint:write": "rslint --fix"
   },
   "gitHooks": {
     "pre-commit": "lint-staged"
@@ -56,6 +57,7 @@
     "@babel/core": "^7.7.7",
     "@babel/preset-env": "^7.11.5",
     "@intlify/vue-i18n-loader": "^3.0.0",
+    "@rslint/core": "^0.5.1",
     "@rspack/core": "^1.7.5",
     "@rstest/core": "^0.7.9",
     "@types/cssesc": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ devDependencies:
   '@intlify/vue-i18n-loader':
     specifier: ^3.0.0
     version: 3.0.0(vue@3.4.3)
+  '@rslint/core':
+    specifier: ^0.5.1
+    version: 0.5.2
   '@rspack/core':
     specifier: ^1.7.5
     version: 1.7.5
@@ -1359,6 +1362,74 @@ packages:
       core-js: 3.47.0
       jiti: 2.6.1
     dev: true
+
+  /@rslint/core@0.5.2:
+    resolution: {integrity: sha512-RDP0uvg0ni1AXl/Jq9LglY8QmSIuM4HN4Lx9Pef6xL1QZrgXkQJ5GKPlBjkbMDu7Zdlfjo1L5D1S0cttaEjBHA==}
+    hasBin: true
+    peerDependencies:
+      jiti: ^2.0.0
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+    dependencies:
+      picomatch: 4.0.4
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@rslint/darwin-arm64': 0.5.2
+      '@rslint/darwin-x64': 0.5.2
+      '@rslint/linux-arm64': 0.5.2
+      '@rslint/linux-x64': 0.5.2
+      '@rslint/win32-arm64': 0.5.2
+      '@rslint/win32-x64': 0.5.2
+    dev: true
+
+  /@rslint/darwin-arm64@0.5.2:
+    resolution: {integrity: sha512-gu7WyZnyZt9x/TMC+jtf0LYTC0Zq9Fq38utef5dcm8iVbdZNqt+EnwrOqVFaqI1ikYC18IOi9aIe7/bxVZp/aA==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rslint/darwin-x64@0.5.2:
+    resolution: {integrity: sha512-sxvIAWldUBd/EeK+PkQhgVbRq6VwHBmUNxKNWyng5zL0gWu02X8ynhyzDgWfUKPXH7BgebSItQBfa4+qFQXhUw==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rslint/linux-arm64@0.5.2:
+    resolution: {integrity: sha512-D8cmoMDqzwZqELtxbVZDX0jGMXkSwAejvOL9D1GXoFAxq74xuT/s0UdfbkzZtAAvIFrwa8PGskPXv3X/1w2WbA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rslint/linux-x64@0.5.2:
+    resolution: {integrity: sha512-b4Nato9LgkPX7OydaeXexUUvkfm4+tRAvp46T4xhe76k136/ziImRPBcM/G7pBNyaV5Rd6qp6CiYW330Q+0Gnw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rslint/win32-arm64@0.5.2:
+    resolution: {integrity: sha512-3pfpABHaBv+Z551cKOX+pVllmGFJc7dLHDs2XignLxZ89xsxomlAx8CLhkaDECUkoBM7gj4/oQr57t9Ndhe3Lw==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rslint/win32-x64@0.5.2:
+    resolution: {integrity: sha512-MnIp0ofyg7AXP+bgt1VW1ejJszkgyFKHJvSqZ3QePOllWKXA7Nhj4lMIluIcTN1D4C0f00+6POYOeIjSwI+aRQ==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@rspack/binding-darwin-arm64@1.7.0:
     resolution: {integrity: sha512-HMYrhvVh3sMRBXl6cSI2JqsvlHJKQ42qX+Sw4qbj7LeZBN6Gv4GjfL3cXRLUTdO37FOC0uLEUYgxVXetx/Y4sA==}
@@ -3861,6 +3932,18 @@ packages:
       websocket-driver: 0.7.4
     dev: true
 
+  /fdir@6.5.0(picomatch@4.0.4):
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+    dependencies:
+      picomatch: 4.0.4
+    dev: true
+
   /figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
@@ -6129,6 +6212,11 @@ packages:
     engines: {node: '>=8.6'}
     dev: true
 
+  /picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+    dev: true
+
   /pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
@@ -7643,6 +7731,14 @@ packages:
 
   /thunky@1.1.0:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
+    dev: true
+
+  /tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
     dev: true
 
   /tinypool@1.1.1:

--- a/rslint.config.ts
+++ b/rslint.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig, js, ts } from '@rslint/core';
+
+export default defineConfig([
+  js.configs.recommended,
+  ts.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/ban-ts-comment': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-require-imports': 'off',
+      '@typescript-eslint/no-this-alias': 'off',
+    },
+  },
+]);

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -13,10 +13,10 @@ try {
   // Vue 3.2.13+ ships the SFC compiler directly under the `vue` package
   // making it no longer necessary to have @vue/compiler-sfc separately installed.
   compiler = require('vue/compiler-sfc')
-} catch (e) {
+} catch {
   try {
     compiler = require('@vue/compiler-sfc')
-  } catch (e) {
+  } catch {
     throw new Error(
       `@vitejs/plugin-vue requires vue (>=3.2.13) or @vue/compiler-sfc ` +
         `to be present in the dependency tree.`

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -14,7 +14,7 @@ const BasicMatcherRulePlugin = require('./rules/BasicMatcherRulePlugin')
 const UseEffectRulePlugin = require('./rules/UseEffectRulePlugin')
 const RuleSetCompiler = require('./rules/RuleSetCompiler') as RuleSetCompiler
 
-let objectMatcherRulePlugins = []
+const objectMatcherRulePlugins = []
 const ObjectMatcherRulePlugin = require('./rules/ObjectMatcherRulePlugin')
 objectMatcherRulePlugins.push(
   new ObjectMatcherRulePlugin('assert', 'assertions'),


### PR DESCRIPTION
This PR adds Rslint as the repository lint entrypoint. It includes `rslint.config.ts`, the `@rslint/core` dev dependency, a VS Code extension recommendation, and a GitHub Actions lint workflow that runs `pnpm run lint`.

A couple of simple Rslint findings were fixed directly, and existing historical TypeScript rule violations are captured in the Rslint config. Validated locally with `pnpm run lint`.
