### PR TITLE
chore: update peer dependency range

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "chalk": "^4.1.0"
   },
   "peerDependencies": {
-    "@rspack/core": "^1.0.0 || ^2.0.0-0"
+    "@rspack/core": "^1.0.0 || ^2.0.0"
   },
   "peerDependenciesMeta": {
     "@rspack/core": {


### PR DESCRIPTION
## Summary

This PR updates peer dependency ranges that still use the prerelease 2.0 floor (`^2.0.0-0`) to the stable 2.x range (`^2.0.0`). It keeps the existing compatibility alternatives where present and does not change runtime code.